### PR TITLE
enhancements/Droid-IndicateListeningInProgress

### DIFF
--- a/src/Plugin.NFC.Sample/Plugin.NFC.Sample/MainPage.xaml
+++ b/src/Plugin.NFC.Sample/Plugin.NFC.Sample/MainPage.xaml
@@ -68,6 +68,14 @@
 			<Label Margin="0,6,0,0"
 				   Padding="12,6"
                    HorizontalOptions="CenterAndExpand"
+                   IsVisible="{Binding DeviceIsListening}"
+                   Text="Listening for NFC Tag..."
+				   FontAttributes="Bold"
+                   TextColor="Blue"/>
+
+			<Label Margin="0,6,0,0"
+				   Padding="12,6"
+                   HorizontalOptions="CenterAndExpand"
                    IsVisible="{Binding NfcIsDisabled}"
                    Text="NFC IS DISABLED"
 				   FontAttributes="Bold"

--- a/src/Plugin.NFC.Sample/Plugin.NFC.Sample/MainPage.xaml.cs
+++ b/src/Plugin.NFC.Sample/Plugin.NFC.Sample/MainPage.xaml.cs
@@ -14,6 +14,22 @@ namespace NFCSample
 
 		NFCNdefTypeFormat _type;
 		bool _makeReadOnly = false;
+		bool _isDeviceiOS = false;
+
+		/// <summary>
+		/// Property that tracks whether the Android device is still listening,
+		/// so it can indicate that to the user.
+		/// </summary>
+		public bool DeviceIsListening
+		{
+			get => _deviceIsListening && NfcIsEnabled;
+			set
+			{
+				_deviceIsListening = value;
+				OnPropertyChanged(nameof(DeviceIsListening));
+			}
+		}
+		private bool _deviceIsListening;
 
 		private bool _nfcIsEnabled;
 		public bool NfcIsEnabled {
@@ -46,13 +62,12 @@ namespace NFCSample
 				if (!NfcIsEnabled)
 					await ShowAlert("NFC is disabled");
 
+				if (Device.RuntimePlatform == Device.iOS)
+					_isDeviceiOS = true;
+
 				SubscribeEvents();
 
-				if (Device.RuntimePlatform != Device.iOS)
-				{
-					// Start NFC tag listening manually
-					CrossNFC.Current.StartListening();
-				}
+				await StartListeningIfNotiOS();
 			}
 		}
 
@@ -70,7 +85,7 @@ namespace NFCSample
 			CrossNFC.Current.OnTagDiscovered += Current_OnTagDiscovered;
 			CrossNFC.Current.OnNfcStatusChanged += Current_OnNfcStatusChanged;
 
-			if (Device.RuntimePlatform == Device.iOS)
+			if (_isDeviceiOS)
 				CrossNFC.Current.OniOSReadingSessionCancelled += Current_OniOSReadingSessionCancelled;
 		}
 
@@ -81,7 +96,7 @@ namespace NFCSample
 			CrossNFC.Current.OnTagDiscovered -= Current_OnTagDiscovered;
 			CrossNFC.Current.OnNfcStatusChanged -= Current_OnNfcStatusChanged;
 
-			if (Device.RuntimePlatform == Device.iOS)
+			if (_isDeviceiOS)
 				CrossNFC.Current.OniOSReadingSessionCancelled -= Current_OniOSReadingSessionCancelled;
 		}
 
@@ -117,6 +132,7 @@ namespace NFCSample
 				var first = tagInfo.Records[0];
 				await ShowAlert(GetMessage(first), title);
 			}
+			DeviceIsListening = false;
 		}
 
 		void Current_OniOSReadingSessionCancelled(object sender, EventArgs e) => Debug("User has cancelled NFC Session");
@@ -194,6 +210,7 @@ namespace NFCSample
 			{
 				await ShowAlert(ex.Message);
 			}
+			DeviceIsListening = false;
 		}
 
 		async void Button_Clicked_StartListening(object sender, System.EventArgs e)
@@ -261,5 +278,33 @@ namespace NFCSample
 		void Debug(string message) => System.Diagnostics.Debug.WriteLine(message);
 
 		Task ShowAlert(string message, string title = null) => DisplayAlert(string.IsNullOrWhiteSpace(title) ? ALERT_TITLE : title, message, "Cancel");
+
+		/// <summary>
+		/// Task to start listening for NFC tags if the user's device platform is not iOS
+		/// </summary>
+		/// <returns>Task to be performed</returns>
+		async Task StartListeningIfNotiOS()
+		{
+			if (_isDeviceiOS)
+				return;
+			await BeginListening();
+		}
+
+		/// <summary>
+		/// Task to safely start listening for NFC Tags
+		/// </summary>
+		/// <returns>The task to be performed</returns>
+		async Task BeginListening()
+		{
+			DeviceIsListening = true;
+			try
+			{
+				CrossNFC.Current.StartListening();
+			}
+			catch (Exception ex)
+			{
+				await ShowAlert(ex.Message);
+			}
+		}
 	}
 }

--- a/src/Plugin.NFC/Shared/INFC.shared.cs
+++ b/src/Plugin.NFC/Shared/INFC.shared.cs
@@ -104,21 +104,20 @@ namespace Plugin.NFC
 	/// </summary>
 	internal static class UIMessages
 	{
-		public const string NFCWritingNotSupported = "Writing NFC Tag is not supported on this device";
-		public const string NFCDialogAlertMessage = "Please hold your phone near a NFC tag";
-
+		public const string NFCWritingNotSupported = "Writing NFC Tag opration is not supported on this device";
+		public const string NFCDialogAlertMessage = "Please hold your phone near an NFC tag";
 		public const string NFCErrorRead = "Read error. Please try again";
 		public const string NFCErrorEmptyTag = "Tag is empty";
 		public const string NFCErrorReadOnlyTag = "Tag is not writable";
 		public const string NFCErrorCapacityTag = "Tag's capacity is too low";
 		public const string NFCErrorMissingTag = "Tag is missing";
-		public const string NFCErrorMissingTagInfo = "No Tag Informations: nothing to write";
+		public const string NFCErrorMissingTagInfo = "No Tag Information. Nothing to write";
 		public const string NFCErrorNotSupportedTag = "Tag is not supported";
 		public const string NFCErrorNotCompliantTag = "Tag is not NDEF compliant";
 		public const string NFCErrorWrite = "Nothing to write";
 
-		public const string NFCSuccessRead = "Tag Read Success";
-		public const string NFCSuccessWrite = "Tag Write Success";
-		public const string NFCSuccessClear = "Tag Clear Success";
+		public const string NFCSuccessRead = "Tag Read Operation Successful";
+		public const string NFCSuccessWrite = "Tag Write Operation Successful";
+		public const string NFCSuccessClear = "Tag Clear Operation Successful";
 	}
 }


### PR DESCRIPTION
### Description of Change ###

* Added a "Listening for NFC tag..." label at the bottom of the Clear button to display when the device is listening for an NFC Tag. This is for better UX, as earlier, Android users were not able to tell when the app is listening for tags
* On iOS, if the device is listening, there's a popup box indicating the listening action. However on Android there was no indication before
* Created a Property DeviceIsListening that determines visibility of the "Listening.." label for Android and appropriately set it to true or false depending on each situation
* DeviceIsListening is not needed for iOS since the user sees the prompt anyway, and cannot be used for iOS because of the DidInvalidate() in Plugin.NFC/iOS/NFC.iOS.cs not being accessible from the Xaml.cs file

**Testing**
----------
* Tested on iOS & Android and it worked fine.
* Tested the different possible failure cases:
  * When the user presses cancel or the NFC prompt times out, the Listening text goes away
  * It indicated how Android keeps listening without a timeout, unlike iOS that times out
  * Tested on iOS & Android devices with and without NFC technology to make sure it works
### Bugs Fixed ###

No existing bugs were filed for these changes

### API Changes ###

Fixed the grammar of some of the UI Error messages
### Behavioral Changes ###

The sample Android app now shows when the Android app is listening for NFC tags.

### PR Checklist ###

- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [N/A] Updated documentation